### PR TITLE
allow parsing results from running jobs

### DIFF
--- a/docs/data/ci-perf-benchmark.csv.py
+++ b/docs/data/ci-perf-benchmark.csv.py
@@ -134,8 +134,8 @@ async def main():
     for build in builds:
 
         # skip running builds
-        if build['state'] == "running":
-            continue
+        # if build['state'] == "running":
+        #     continue
 
         commit = build['commit']
         commit_url = f"{build['pipeline']['repository'].replace('.git', '')}/commit/{build['commit']}"


### PR DESCRIPTION
This PR allows parsing results from running jobs, so that we can still update the performance dashboard when one of the performance benchmark agent dies.